### PR TITLE
Correct resize options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Image resizing requires a configuration array to be passed.
 Available methods are:
     - scale
     - fit
-    - shrink
+    - cover
 
 See [TinyPng docs](https://tinypng.com/developers/reference/php#resizing-and-compressing-images) for information about each method.
 

--- a/TinyPng.php
+++ b/TinyPng.php
@@ -107,7 +107,7 @@ class TinyPng extends Component
      * Available methods are:
      *     - scale
      *     - fit
-     *     - shrink
+     *     - cover
      *
      * See [TinyPng docs](https://tinypng.com/developers/reference/php) for information about each method.
      */


### PR DESCRIPTION
Change the documentation to match the TinyPng documentation regarding resizing methods. 

https://tinypng.com/developers/reference/php#resizing-images 

Correct options are: 
- scale
- fit
- cover 
